### PR TITLE
lpc_iocon driver improvements

### DIFF
--- a/drivers/lpc_iocon/fsl_iocon.h
+++ b/drivers/lpc_iocon/fsl_iocon.h
@@ -48,7 +48,6 @@ typedef struct _iocon_group
  * @brief IOCON function and mode selection definitions
  * @note See the User Manual for specific modes and functions supported by the various pins.
  */
-#if defined(FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH) && (FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH == 4)
 #define IOCON_FUNC0  0x0 /*!< Selects pin function 0 */
 #define IOCON_FUNC1  0x1 /*!< Selects pin function 1 */
 #define IOCON_FUNC2  0x2 /*!< Selects pin function 2 */
@@ -57,6 +56,7 @@ typedef struct _iocon_group
 #define IOCON_FUNC5  0x5 /*!< Selects pin function 5 */
 #define IOCON_FUNC6  0x6 /*!< Selects pin function 6 */
 #define IOCON_FUNC7  0x7 /*!< Selects pin function 7 */
+#if defined(FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH) && (FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH == 4)
 #define IOCON_FUNC8  0x8 /*!< Selects pin function 8 */
 #define IOCON_FUNC9  0x9 /*!< Selects pin function 9 */
 #define IOCON_FUNC10 0xA /*!< Selects pin function 10 */
@@ -65,6 +65,8 @@ typedef struct _iocon_group
 #define IOCON_FUNC13 0xD /*!< Selects pin function 13 */
 #define IOCON_FUNC14 0xE /*!< Selects pin function 14 */
 #define IOCON_FUNC15 0xF /*!< Selects pin function 15 */
+#endif /* FSL_FEATURE_IOCON_FUNC_FIELD_WIDTH */
+
 #if defined(IOCON_PIO_MODE_SHIFT)
 #define IOCON_MODE_INACT    (0x0 << IOCON_PIO_MODE_SHIFT) /*!< No addition pin function */
 #define IOCON_MODE_PULLDOWN (0x1 << IOCON_PIO_MODE_SHIFT) /*!< Selects pull-down function */
@@ -150,83 +152,6 @@ typedef struct _iocon_group
      << IOCON_PIO_CLK_DIV_SHIFT) /*!< Select peripheral clock divider for input filter sampling clock, 2^n, n=0-6 */
 #endif
 
-#else
-#define IOCON_FUNC0 0x0 /*!< Selects pin function 0 */
-#define IOCON_FUNC1 0x1 /*!< Selects pin function 1 */
-#define IOCON_FUNC2 0x2 /*!< Selects pin function 2 */
-#define IOCON_FUNC3 0x3 /*!< Selects pin function 3 */
-#define IOCON_FUNC4 0x4 /*!< Selects pin function 4 */
-#define IOCON_FUNC5 0x5 /*!< Selects pin function 5 */
-#define IOCON_FUNC6 0x6 /*!< Selects pin function 6 */
-#define IOCON_FUNC7 0x7 /*!< Selects pin function 7 */
-
-#if defined(IOCON_PIO_MODE_SHIFT)
-#define IOCON_MODE_INACT    (0x0 << IOCON_PIO_MODE_SHIFT) /*!< No addition pin function */
-#define IOCON_MODE_PULLDOWN (0x1 << IOCON_PIO_MODE_SHIFT) /*!< Selects pull-down function */
-#define IOCON_MODE_PULLUP   (0x2 << IOCON_PIO_MODE_SHIFT) /*!< Selects pull-up function */
-#define IOCON_MODE_REPEATER (0x3 << IOCON_PIO_MODE_SHIFT) /*!< Selects pin repeater function */
-#endif
-
-#if defined(IOCON_PIO_I2CSLEW_SHIFT)
-#define IOCON_GPIO_MODE (0x1 << IOCON_PIO_I2CSLEW_SHIFT) /*!< GPIO Mode */
-#define IOCON_I2C_SLEW  (0x0 << IOCON_PIO_I2CSLEW_SHIFT) /*!< I2C Slew Rate Control */
-#endif
-
-#if defined(IOCON_PIO_EGP_SHIFT)
-#define IOCON_GPIO_MODE (0x1 << IOCON_PIO_EGP_SHIFT) /*!< GPIO Mode */
-#define IOCON_I2C_SLEW  (0x0 << IOCON_PIO_EGP_SHIFT) /*!< I2C Slew Rate Control */
-#endif
-
-#if defined(IOCON_PIO_INVERT_SHIFT)
-#define IOCON_INV_EN (0x1 << IOCON_PIO_INVERT_SHIFT) /*!< Enables invert function on input */
-#endif
-
-#if defined(IOCON_PIO_DIGIMODE_SHIFT)
-#define IOCON_ANALOG_EN (0x0 << IOCON_PIO_DIGIMODE_SHIFT) /*!< Enables analog function by setting 0 to bit 7 */
-#define IOCON_DIGITAL_EN \
-    (0x1 << IOCON_PIO_DIGIMODE_SHIFT) /*!< Enables digital function by setting 1 to bit 7(default) */
-#endif
-
-#if defined(IOCON_PIO_FILTEROFF_SHIFT)
-#define IOCON_INPFILT_OFF (0x1 << IOCON_PIO_FILTEROFF_SHIFT) /*!< Input filter Off for GPIO pins */
-#define IOCON_INPFILT_ON  (0x0 << IOCON_PIO_FILTEROFF_SHIFT) /*!< Input filter On for GPIO pins */
-#endif
-
-#if defined(IOCON_PIO_I2CDRIVE_SHIFT)
-#define IOCON_I2C_LOWDRIVER  (0x0 << IOCON_PIO_I2CDRIVE_SHIFT) /*!< Low drive, Output drive sink is 4 mA */
-#define IOCON_I2C_HIGHDRIVER (0x1 << IOCON_PIO_I2CDRIVE_SHIFT) /*!< High drive, Output drive sink is 20 mA */
-#endif
-
-#if defined(IOCON_PIO_OD_SHIFT)
-#define IOCON_OPENDRAIN_EN (0x1 << IOCON_PIO_OD_SHIFT) /*!< Enables open-drain function */
-#endif
-
-#if defined(IOCON_PIO_I2CFILTER_SHIFT)
-#define IOCON_I2CFILTER_OFF (0x1 << IOCON_PIO_I2CFILTER_SHIFT) /*!<  I2C 50 ns glitch filter enabled */
-#define IOCON_I2CFILTER_ON  (0x0 << IOCON_PIO_I2CFILTER_SHIFT) /*!<  I2C 50 ns glitch filter not enabled */
-#endif
-
-#if defined(IOCON_PIO_S_MODE_SHIFT)
-#define IOCON_S_MODE_0CLK (0x0 << IOCON_PIO_S_MODE_SHIFT) /*!< Bypass input filter */
-#define IOCON_S_MODE_1CLK                                                                              \
-    (0x1 << IOCON_PIO_S_MODE_SHIFT) /*!< Input pulses shorter than 1 filter clock are rejected \ \ \ \ \
-                                     */
-#define IOCON_S_MODE_2CLK                                                                               \
-    (0x2 << IOCON_PIO_S_MODE_SHIFT) /*!< Input pulses shorter than 2 filter clock2 are rejected \ \ \ \ \
-                                     */
-#define IOCON_S_MODE_3CLK                                                                               \
-    (0x3 << IOCON_PIO_S_MODE_SHIFT) /*!< Input pulses shorter than 3 filter clock2 are rejected \ \ \ \ \
-                                     */
-#define IOCON_S_MODE(clks) ((clks) << IOCON_PIO_S_MODE_SHIFT) /*!< Select clocks for digital input filter mode */
-#endif
-
-#if defined(IOCON_PIO_CLK_DIV_SHIFT)
-#define IOCON_CLKDIV(div) \
-    ((div)                \
-     << IOCON_PIO_CLK_DIV_SHIFT) /*!< Select peripheral clock divider for input filter sampling clock, 2^n, n=0-6 */
-#endif
-
-#endif
 #if defined(__cplusplus)
 extern "C" {
 #endif

--- a/drivers/lpc_iocon/fsl_iocon.h
+++ b/drivers/lpc_iocon/fsl_iocon.h
@@ -81,7 +81,8 @@ typedef struct _iocon_group
 
 #if defined(IOCON_PIO_EGP_SHIFT)
 #define IOCON_GPIO_MODE (0x1 << IOCON_PIO_EGP_SHIFT) /*!< GPIO Mode */
-#define IOCON_I2C_SLEW  (0x0 << IOCON_PIO_EGP_SHIFT) /*!< I2C Slew Rate Control */
+#define IOCON_I2C_MODE  (0x0 << IOCON_PIO_EGP_SHIFT) /*!< I2C Slew Rate Control */
+#define IOCON_I2C_SLEW  IOCON_I2C_MODE /*!< Deprecated name for #IOCON_I2C_MODE */
 #endif
 
 #if defined(IOCON_PIO_SLEW_SHIFT)

--- a/drivers/lpc_iocon_lite/fsl_iocon.h
+++ b/drivers/lpc_iocon_lite/fsl_iocon.h
@@ -39,7 +39,7 @@
 typedef struct _iocon_group
 {
     uint32_t ionumber : 8;  /* IO number */
-    uint32_t modefunc : 16; /* Function and mode */
+    uint32_t modefunc : 24; /* Function and mode */
 } iocon_group_t;
 
 /**


### PR DESCRIPTION
Some improvements to the lpc_iocon and lpc_icon_lite drivers.

lpc_icon:
- Removed duplicate macro defintions.
- Renamed `IOCON_I2C_SLEW` macro to `IOCON_I2C_MODE` to match its companion `IOCON_GPIO_MODE`. The original is kept as a deprecated symbol.

lpc_icon_lite:
- Fixed the size of the `iocon_group_t::modefunc` struct member. It was 16 bits wide, but the `IOCON_DAC_MODE_EN` flag has a bit shift of 16, meaning it won't fit into the bitfield. In practice it probably worked because the bitfield type is `uint32_t` but only 24 bits were defined. But the behaviour is undefined by the C language.

I can bump the micro versions of the drivers if you like.