### PR TITLE
Support for multichannel SAI EDMA transfers

### DIFF
--- a/drivers/sai/fsl_sai_edma.c
+++ b/drivers/sai/fsl_sai_edma.c
@@ -252,6 +252,7 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
     }
 
     /* Update the data channel SAI used */
+    handle->channelMask = format->channelMask;
     handle->channel = format->channel;
 
     /* Clear the channel enable bits until do a send/receive */
@@ -266,6 +267,18 @@ void SAI_TransferTxSetFormatEDMA(I2S_Type *base,
 /*!
  * @brief Configures the SAI Tx.
  *
+ * @note SAI eDMA supports data transfer in a multiple SAI channels if the FIFO Combine feature is supported.
+ * To activate the multi-channel transfer enable SAI channels by filling the channelMask 
+ * of sai_transceiver_t with the corresponding values of _sai_channel_mask enum, enable the FIFO Combine 
+ * mode by assigning kSAI_FifoCombineModeEnabledOnWrite to the fifoCombine member of sai_fifo_combine_t 
+ * which is a member of sai_transceiver_t.
+ * This is an example of multi-channel data transfer configuration step.
+   @code
+    sai_transceiver_t config;
+    SAI_GetClassicI2SConfig(&config, kSAI_WordWidth16bits, kSAI_Stereo, kSAI_Channel0Mask|kSAI_Channel1Mask);
+    config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnWrite;
+    SAI_TransferTxSetConfigEDMA(I2S0, &edmaHandle, &config);
+   @endcode
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -278,6 +291,13 @@ void SAI_TransferTxSetConfigEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     /* Configure the audio format to SAI registers */
     SAI_TxSetConfig(base, saiConfig);
 
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE
+    /* Allow multi-channel transfer only if FIFO Combine mode is enabled */
+    assert((saiConfig->channelNums <= 1) || ((saiConfig->channelNums > 1) &&
+            ((saiConfig->fifo.fifoCombine == kSAI_FifoCombineModeEnabledOnWrite) || 
+             (saiConfig->fifo.fifoCombine == kSAI_FifoCombineModeEnabledOnReadWrite))));
+#endif
+
     /* Get the transfer size from format, this should be used in EDMA configuration */
     if (saiConfig->serialData.dataWordLength == 24U)
     {
@@ -287,7 +307,9 @@ void SAI_TransferTxSetConfigEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     {
         handle->bytesPerFrame = saiConfig->serialData.dataWordLength / 8U;
     }
+
     /* Update the data channel SAI used */
+    handle->channelMask = saiConfig->channelMask;
     handle->channel = saiConfig->startChannel;
 
     /* Clear the channel enable bits until do a send/receive */
@@ -336,6 +358,7 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
     }
 
     /* Update the data channel SAI used */
+    handle->channelMask = format->channelMask;
     handle->channel = format->channel;
 
     /* Clear the channel enable bits until do a send/receive */
@@ -350,6 +373,18 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
 /*!
  * @brief Configures the SAI Rx.
  *
+ * @note SAI eDMA supports data transfer in a multiple SAI channels if the FIFO Combine feature is supported.
+ * To activate the multi-channel transfer enable SAI channels by filling the channelMask 
+ * of sai_transceiver_t with the corresponding values of _sai_channel_mask enum, enable the FIFO Combine 
+ * mode by assigning kSAI_FifoCombineModeEnabledOnRead to the fifoCombine member of sai_fifo_combine_t 
+ * which is a member of sai_transceiver_t.
+ * This is an example of multi-channel data transfer configuration step.
+   @code
+    sai_transceiver_t config;
+    SAI_GetClassicI2SConfig(&config, kSAI_WordWidth16bits, kSAI_Stereo, kSAI_Channel0Mask|kSAI_Channel1Mask);
+    config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnRead;
+    SAI_TransferRxSetConfigEDMA(I2S0, &edmaHandle, &config);
+   @endcode
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -362,6 +397,13 @@ void SAI_TransferRxSetConfigEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     /* Configure the audio format to SAI registers */
     SAI_RxSetConfig(base, saiConfig);
 
+#if defined(FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE) && FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE
+    /* Allow multi-channel transfer only if FIFO Combine mode is enabled */
+    assert((saiConfig->channelNums <= 1) || ((saiConfig->channelNums > 1) &&
+            ((saiConfig->fifo.fifoCombine == kSAI_FifoCombineModeEnabledOnRead) || 
+             (saiConfig->fifo.fifoCombine == kSAI_FifoCombineModeEnabledOnReadWrite))));
+#endif
+
     /* Get the transfer size from format, this should be used in EDMA configuration */
     if (saiConfig->serialData.dataWordLength == 24U)
     {
@@ -373,6 +415,7 @@ void SAI_TransferRxSetConfigEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     }
 
     /* Update the data channel SAI used */
+    handle->channelMask = saiConfig->channelMask;
     handle->channel = saiConfig->startChannel;
 
     /* Clear the channel enable bits until do a send/receive */
@@ -446,7 +489,7 @@ status_t SAI_TransferSendEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_tra
     SAI_TxEnable(base, true);
 
     /* Enable the channel FIFO */
-    base->TCR3 |= I2S_TCR3_TCE(1UL << handle->channel);
+    base->TCR3 |= I2S_TCR3_TCE(handle->channelMask);
 
     return kStatus_Success;
 }
@@ -510,7 +553,7 @@ status_t SAI_TransferReceiveEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
     SAI_RxEnableDMA(base, kSAI_FIFORequestDMAEnable, true);
 
     /* Enable the channel FIFO */
-    base->RCR3 |= I2S_RCR3_RCE(1UL << handle->channel);
+    base->RCR3 |= I2S_RCR3_RCE(handle->channelMask);
 
     /* Enable SAI Rx clock */
     SAI_RxEnable(base, true);

--- a/drivers/sai/fsl_sai_edma.h
+++ b/drivers/sai/fsl_sai_edma.h
@@ -36,6 +36,7 @@ struct sai_edma_handle
     edma_handle_t *dmaHandle;     /*!< DMA handler for SAI send */
     uint8_t nbytes;               /*!< eDMA minor byte transfer count initially configured. */
     uint8_t bytesPerFrame;        /*!< Bytes in a frame */
+    uint8_t channelMask;          /*!< Enabled channel mask value, reference _sai_channel_mask */
     uint8_t channel;              /*!< Which data channel */
     uint8_t count;                /*!< The transfer data count in a DMA request */
     uint32_t state;               /*!< Internal state for SAI eDMA transfer */
@@ -143,6 +144,18 @@ void SAI_TransferRxSetFormatEDMA(I2S_Type *base,
 /*!
  * @brief Configures the SAI Tx.
  *
+ * @note SAI eDMA supports data transfer in a multiple SAI channels if the FIFO Combine feature is supported.
+ * To activate the multi-channel transfer enable SAI channels by filling the channelMask 
+ * of sai_transceiver_t with the corresponding values of _sai_channel_mask enum, enable the FIFO Combine 
+ * mode by assigning kSAI_FifoCombineModeEnabledOnWrite to the fifoCombine member of sai_fifo_combine_t 
+ * which is a member of sai_transceiver_t.
+ * This is an example of multi-channel data transfer configuration step.
+   @code
+    sai_transceiver_t config;
+    SAI_GetClassicI2SConfig(&config, kSAI_WordWidth16bits, kSAI_Stereo, kSAI_Channel0Mask|kSAI_Channel1Mask);
+    config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnWrite;
+    SAI_TransferTxSetConfigEDMA(I2S0, &edmaHandle, &config);
+   @endcode
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.
@@ -153,6 +166,18 @@ void SAI_TransferTxSetConfigEDMA(I2S_Type *base, sai_edma_handle_t *handle, sai_
 /*!
  * @brief Configures the SAI Rx.
  *
+ * @note SAI eDMA supports data transfer in a multiple SAI channels if the FIFO Combine feature is supported.
+ * To activate the multi-channel transfer enable SAI channels by filling the channelMask 
+ * of sai_transceiver_t with the corresponding values of _sai_channel_mask enum, enable the FIFO Combine 
+ * mode by assigning kSAI_FifoCombineModeEnabledOnRead to the fifoCombine member of sai_fifo_combine_t 
+ * which is a member of sai_transceiver_t.
+ * This is an example of multi-channel data transfer configuration step.
+   @code
+    sai_transceiver_t config;
+    SAI_GetClassicI2SConfig(&config, kSAI_WordWidth16bits, kSAI_Stereo, kSAI_Channel0Mask|kSAI_Channel1Mask);
+    config.fifo.fifoCombine = kSAI_FifoCombineModeEnabledOnRead;
+    SAI_TransferRxSetConfigEDMA(I2S0, &edmaHandle, &config);
+   @endcode
  *
  * @param base SAI base pointer.
  * @param handle SAI eDMA handle pointer.


### PR DESCRIPTION
**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Currently API for SAI EDMA transfers assumes that audio data can only be interleaved (e.g. sent via a single wire I2S0_TXD0) but for example K66/K26 MCUs support output of non-interlieved audio using 2 wires via the I2S0_TXD0 and I2S0_TXD1 pins.

The proposed change allows to send non-interlieved data using SAI EDMA mechanism. In our case this method works successfully for transmitting native DSD non-interlieved data to ESS Technology audio DACs (ES9218P, ES9038Q2M).

**Type of change** (please delete options that are not relevant):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting: K66/K26, ES9218P or ES9038Q2M
   - Toolchain:
   - Test Tool preparation:
   - Any other dependencies:
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [ ] Build Test
    - [x] Run Test: connect I2S0_TXD0 and I2S0_TXD1 pins of MCU to the receiver (audio DAC) that accepts non-interlieved input.

