### PR TITLE
Add DbgConsole_Vprintf/DbgConsole_BlockingVprintf new API

### DIFF
--- a/utilities/debug_console/debug_console/fsl_debug_console.c
+++ b/utilities/debug_console/debug_console/fsl_debug_console.c
@@ -990,23 +990,32 @@ DEBUG_CONSOLE_FUNCTION_PREFIX status_t DbgConsole_Flush(void)
 
 #if SDK_DEBUGCONSOLE
 /* See fsl_debug_console.h for documentation of this function. */
-int DbgConsole_Printf(const char *fmt_s, ...)
+int DbgConsole_Printf(const char *formatString, ...)
 {
     va_list ap;
-    int logLength = 0, dbgResult = 0;
+    int result;
+
+    va_start(ap, formatString);
+    result = DbgConsole_Vprintf(formatString, ap);
+    va_end(ap);
+
+    return result;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Vprintf(const char *formatString, va_list formatStringArg)
+{
+    int logLength = 0, result = 0;
     char printBuf[DEBUG_CONSOLE_PRINTF_MAX_LOG_LEN] = {'\0'};
 
     if (NULL != g_serialHandle)
     {
-        va_start(ap, fmt_s);
         /* format print log first */
-        logLength = StrFormatPrintf(fmt_s, ap, printBuf, DbgConsole_PrintCallback);
+        logLength = StrFormatPrintf(formatString, formatStringArg, printBuf, DbgConsole_PrintCallback);
         /* print log */
-        dbgResult = DbgConsole_SendDataReliable((uint8_t *)printBuf, (size_t)logLength);
-
-        va_end(ap);
+        result = DbgConsole_SendDataReliable((uint8_t *)printBuf, (size_t)logLength);
     }
-    return dbgResult;
+    return result;
 }
 
 /* See fsl_debug_console.h for documentation of this function. */
@@ -1034,12 +1043,25 @@ int DbgConsole_Scanf(char *formatString, ...)
 
     return formatResult;
 }
+
 /* See fsl_debug_console.h for documentation of this function. */
 int DbgConsole_BlockingPrintf(const char *formatString, ...)
 {
     va_list ap;
+    int result;
+
+    va_start(ap, formatString);
+    result = DbgConsole_BlockingVprintf(formatString, ap);
+    va_end(ap);
+
+    return result;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_BlockingVprintf(const char *formatString, va_list formatStringArg)
+{
     status_t status;
-    int logLength = 0, dbgResult = 0;
+    int logLength, result;
     char printBuf[DEBUG_CONSOLE_PRINTF_MAX_LOG_LEN] = {'\0'};
 
     if (NULL == g_serialHandle)
@@ -1047,9 +1069,8 @@ int DbgConsole_BlockingPrintf(const char *formatString, ...)
         return 0;
     }
 
-    va_start(ap, formatString);
     /* format print log first */
-    logLength = StrFormatPrintf(formatString, ap, printBuf, DbgConsole_PrintCallback);
+    logLength = StrFormatPrintf(formatString, formatStringArg, printBuf, DbgConsole_PrintCallback);
 
 #if defined(DEBUG_CONSOLE_TRANSFER_NON_BLOCKING)
     (void)SerialManager_CancelWriting(((serial_write_handle_t)&s_debugConsoleState.serialWriteHandleBuffer[0]));
@@ -1058,10 +1079,9 @@ int DbgConsole_BlockingPrintf(const char *formatString, ...)
     status =
         (status_t)SerialManager_WriteBlocking(((serial_write_handle_t)&s_debugConsoleState.serialWriteHandleBuffer[0]),
                                               (uint8_t *)printBuf, (size_t)logLength);
-    dbgResult = (((status_t)kStatus_Success == status) ? (int)logLength : -1);
-    va_end(ap);
+    result = (((status_t)kStatus_Success == status) ? (int)logLength : -1);
 
-    return dbgResult;
+    return result;
 }
 
 #ifdef DEBUG_CONSOLE_TRANSFER_NON_BLOCKING

--- a/utilities/debug_console/debug_console/fsl_debug_console.h
+++ b/utilities/debug_console/debug_console/fsl_debug_console.h
@@ -50,6 +50,8 @@ extern serial_handle_t g_serialHandle; /*!< serial manager handle */
 
 #if defined(SDK_DEBUGCONSOLE) && !(SDK_DEBUGCONSOLE)
 #include <stdio.h>
+#else
+#include <stdarg.h>
 #endif
 
 /*! @brief Definition to select redirect toolchain printf, scanf to uart or not.
@@ -200,10 +202,21 @@ static inline status_t DbgConsole_ExitLowpower(void)
  *
  * Call this function to write a formatted output to the standard output stream.
  *
- * @param   fmt_s Format control string.
+ * @param   formatString Format control string.
  * @return  Returns the number of characters printed or a negative value if an error occurs.
  */
-int DbgConsole_Printf(const char *fmt_s, ...);
+int DbgConsole_Printf(const char *formatString, ...);
+
+/*!
+ * @brief Writes formatted output to the standard output stream.
+ *
+ * Call this function to write a formatted output to the standard output stream.
+ *
+ * @param   formatString Format control string.
+ * @param   formatStringArg Format arguments.
+ * @return  Returns the number of characters printed or a negative value if an error occurs.
+ */
+int DbgConsole_Vprintf(const char *formatString, va_list formatStringArg);
 
 /*!
  * @brief Writes a character to stdout.
@@ -258,6 +271,20 @@ int DbgConsole_Getchar(void);
  * @return  Returns the number of characters printed or a negative value if an error occurs.
  */
 int DbgConsole_BlockingPrintf(const char *formatString, ...);
+
+/*!
+ * @brief Writes formatted output to the standard output stream with the blocking mode.
+ *
+ * Call this function to write a formatted output to the standard output stream with the blocking mode.
+ * The function will send data with blocking mode no matter the DEBUG_CONSOLE_TRANSFER_NON_BLOCKING set
+ * or not.
+ * The function could be used in system ISR mode with DEBUG_CONSOLE_TRANSFER_NON_BLOCKING set.
+ *
+ * @param   formatString Format control string.
+ * @param   formatStringArg Format arguments.
+ * @return  Returns the number of characters printed or a negative value if an error occurs.
+ */
+int DbgConsole_BlockingVprintf(const char *formatString, va_list formatStringArg);
 
 /*!
  * @brief Debug console flush.

--- a/utilities/debug_console_lite/fsl_debug_console.c
+++ b/utilities/debug_console_lite/fsl_debug_console.c
@@ -162,20 +162,30 @@ status_t DbgConsole_Deinit(void)
 
 #if SDK_DEBUGCONSOLE
 /* See fsl_debug_console.h for documentation of this function. */
-int DbgConsole_Printf(const char *fmt_s, ...)
+int DbgConsole_Printf(const char *formatString, ...)
 {
     va_list ap;
     int result;
 
+    va_start(ap, formatString);
+    result = DbgConsole_Vprintf(formatString, ap);
+    va_end(ap);
+
+    return result;
+}
+
+/* See fsl_debug_console.h for documentation of this function. */
+int DbgConsole_Vprintf(const char *formatString, va_list formatStringArg)
+{
+    int result;
+    
     /* Do nothing if the debug UART is not initialized. */
     if (kSerialPort_None == s_debugConsole.type)
     {
         return -1;
     }
-    va_start(ap, fmt_s);
-    result = DbgConsole_PrintfFormattedData(DbgConsole_Putchar, fmt_s, ap);
-    va_end(ap);
-
+    result = DbgConsole_PrintfFormattedData(DbgConsole_Putchar, formatString, formatStringArg);
+    
     return result;
 }
 
@@ -193,7 +203,7 @@ int DbgConsole_Putchar(int ch)
 }
 
 /* See fsl_debug_console.h for documentation of this function. */
-int DbgConsole_Scanf(char *fmt_ptr, ...)
+int DbgConsole_Scanf(char *formatString, ...)
 {
     /* Plus one to store end of string char */
     char temp_buf[IO_MAXLINE + 1];
@@ -206,7 +216,7 @@ int DbgConsole_Scanf(char *fmt_ptr, ...)
     {
         return -1;
     }
-    va_start(ap, fmt_ptr);
+    va_start(ap, formatString);
     temp_buf[0] = '\0';
 
     i = 0;
@@ -245,7 +255,7 @@ int DbgConsole_Scanf(char *fmt_ptr, ...)
     {
         temp_buf[i + 1] = '\0';
     }
-    result = (char)DbgConsole_ScanfFormattedData(temp_buf, fmt_ptr, ap);
+    result = (char)DbgConsole_ScanfFormattedData(temp_buf, formatString, ap);
     va_end(ap);
 
     return (int)result;
@@ -544,8 +554,8 @@ static int32_t DbgConsole_ConvertFloatRadixNumToString(char *numstr,
  * (*func_ptr)(c);
  *
  * @param[in] func_ptr  Function to put character out.
- * @param[in] fmt_ptr   Format string for printf.
- * @param[in] args_ptr  Arguments to printf.
+ * @param[in] fmt       Format string for printf.
+ * @param[in] ap        Arguments to printf.
  *
  * @return Number of characters
  */

--- a/utilities/debug_console_lite/fsl_debug_console.h
+++ b/utilities/debug_console_lite/fsl_debug_console.h
@@ -45,6 +45,8 @@
 
 #if defined(SDK_DEBUGCONSOLE) && !(SDK_DEBUGCONSOLE)
 #include <stdio.h>
+#else
+#include <stdarg.h>
 #endif
 
 /*! @brief Definition to printf the float number. */
@@ -177,10 +179,21 @@ static inline status_t DbgConsole_Deinit(void)
  *
  * Call this function to write a formatted output to the standard output stream.
  *
- * @param   fmt_s Format control string.
+ * @param   formatString Format control string.
  * @return  Returns the number of characters printed or a negative value if an error occurs.
  */
-int DbgConsole_Printf(const char *fmt_s, ...);
+int DbgConsole_Printf(const char *formatString, ...);
+
+/*!
+ * @brief Writes formatted output to the standard output stream.
+ *
+ * Call this function to write a formatted output to the standard output stream.
+ *
+ * @param   formatString Format control string.
+ * @param   formatStringArg Format arguments.
+ * @return  Returns the number of characters printed or a negative value if an error occurs.
+ */
+int DbgConsole_Vprintf(const char *formatString, va_list formatStringArg);
 
 /*!
  * @brief Writes a character to stdout.
@@ -197,10 +210,10 @@ int DbgConsole_Putchar(int ch);
  *
  * Call this function to read formatted data from the standard input stream.
  *
- * @param   fmt_ptr Format control string.
+ * @param   formatString Format control string.
  * @return  Returns the number of fields successfully converted and assigned.
  */
-int DbgConsole_Scanf(char *fmt_ptr, ...);
+int DbgConsole_Scanf(char *formatString, ...);
 
 /*!
  * @brief Reads a character from standard input.


### PR DESCRIPTION
to make it possible to wrap SDK's logging into a higher level user-side logging API.

**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Current SDK's logging API (`DbgConsole_Printf`) is sufficient in case user-side implementation is using only NXP's logging but in reality it is not always true and for better debugging (for example when MCUXpresso IDE can not be used) some additional logging can be required, for example the one offered by Segger's J-Link RTT Viewer (a standalone console logging utility) and its companion API (`SEGGER_RTT_vprintf`).

User would want to wrap logging into a single logging function or logging C++ class but absence of vprintf-like API makes it really troublesome.

This PR adds vprintf functionality to the SDK and makes it possible to wrap SDK's logging API easily into a user-side wrapper. For example (pseudocode):

```cpp
#if defined(SDK_DEBUGCONSOLE) && (SDK_DEBUGCONSOLE > 0)
void NxpDebugConsoleLogger::Warn(const char *format, ...)
{
    va_list args;
    va_start(args, format);

    DbgConsole_Vprintf(format, args);

    va_end(args);
}
#else
void SeggerRttLogger::Warn(const char *format, ...)
{
    va_list args;
    va_start(args, format);

    SEGGER_RTT_vprintf(0, format, &args);

    va_end(args);
}
#endif
```

As you can see NXP SDK's co-exist with Segger's vprintf API in a harmony and a user-side implementation is easy and straight forward. This change does not break the API and therefore safe to add without breaking compatibility with the existing user code, it is operating in the production code for around 1 year and works as expected.

PR also corrects the parameter names of the corresponding functions to make them in-line with the parameters of other functions (self descriptive, camel style).

**Type of change** (please delete options that are not relevant):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting:
   - Toolchain:
   - Test Tool preparation:
   - Any other dependencies:
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [x] Build Test
    - [x] Run Test

