### PR TITLE
Fix syntax error reported by ld 2.37

### DIFF
--- a/devices/MIMXRT1011/gcc/MIMXRT1011xxxxx_flexspi_nor.ld
+++ b/devices/MIMXRT1011/gcc/MIMXRT1011xxxxx_flexspi_nor.ld
@@ -56,7 +56,7 @@ SECTIONS
     . = ALIGN(4);
   } > m_flash_config
 
-  ivt_begin= ORIGIN(m_flash_config) + LENGTH(m_flash_config);
+  ivt_begin = ORIGIN(m_flash_config) + LENGTH(m_flash_config);
 
   .ivt : AT(ivt_begin)
   {


### PR DESCRIPTION
Fixes a syntax error in the linker script that is reported by ld 2.37

> LINK _build/mimxrt1010_evk/cdc_msc.elf
/usr/lib/gcc/arm-none-eabi/10.3.0/../../../../arm-none-eabi/bin/ld:/home/tannewt/repos/tinyusb/hw/mcu/nxp/mcux-sdk/devices/MIMXRT1011/gcc/MIMXRT1011xxxxx_flexspi_nor.ld:59: syntax error