### PR TITLE
Fix handling of TX complete interrupt in LPUART EDMA

### DIFF
--- a/drivers/lpuart/fsl_lpuart_edma.c
+++ b/drivers/lpuart/fsl_lpuart_edma.c
@@ -465,15 +465,18 @@ void LPUART_TransferEdmaHandleIRQ(LPUART_Type *base, void *lpuartEdmaHandle)
 {
     assert(lpuartEdmaHandle != NULL);
 
-    lpuart_edma_handle_t *handle = (lpuart_edma_handle_t *)lpuartEdmaHandle;
-
-    /* Disable tx complete interrupt */
-    LPUART_DisableInterrupts(base, (uint32_t)kLPUART_TransmissionCompleteInterruptEnable);
-
-    handle->txState = (uint8_t)kLPUART_TxIdle;
-
-    if (handle->callback != NULL)
+    if (kLPUART_TransmissionCompleteFlag & LPUART_GetStatusFlags(base))
     {
-        handle->callback(base, handle, kStatus_LPUART_TxIdle, handle->userData);
+        lpuart_edma_handle_t *handle = (lpuart_edma_handle_t *)lpuartEdmaHandle;
+
+        /* Disable tx complete interrupt */
+        LPUART_DisableInterrupts(base, (uint32_t)kLPUART_TransmissionCompleteInterruptEnable);
+
+        handle->txState = (uint8_t)kLPUART_TxIdle;
+
+        if (handle->callback != NULL)
+        {
+            handle->callback(base, handle, kStatus_LPUART_TxIdle, handle->userData);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a potential issue that could happen if the user of the driver enables other UART interrupts.

**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

A clear and concise description for the change in this Pull Request and which issue is fixed. 

Fixes # (issue)

**Type of change** (please delete options that are not relevant):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting:
   - Toolchain:
   - Test Tool preparation:
   - Any other dependencies:
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [ ] Build Test
    - [ ] Run Test

