### PR TITLE
Improved some docs for LPUART_EDMA driver

### DIFF
--- a/drivers/lpuart/fsl_lpuart_edma.h
+++ b/drivers/lpuart/fsl_lpuart_edma.h
@@ -69,6 +69,9 @@ extern "C" {
 
 /*!
  * @brief Initializes the LPUART handle which is used in transactional functions.
+ *
+ * @note This function disables all interrupts on the LPUART peripheral.
+ *
  * @param base LPUART peripheral base address.
  * @param handle Pointer to lpuart_edma_handle_t structure.
  * @param callback Callback function.
@@ -88,6 +91,10 @@ void LPUART_TransferCreateHandleEDMA(LPUART_Type *base,
  *
  * This function sends data using eDMA. This is a non-blocking function, which returns
  * right away. When all data is sent, the send callback function is called.
+ *
+ * Important: If the IRQHandler for the LPUART peripheral is overridden,
+ * then `LPUART_TransferEdmaHandleIRQ()` must be called from the interrupt handler when
+ * the `kLPUART_TransmissionCompleteFlag` status flag is set.
  *
  * @param base LPUART peripheral base address.
  * @param handle LPUART handle pointer.
@@ -166,7 +173,9 @@ status_t LPUART_TransferGetReceiveCountEDMA(LPUART_Type *base, lpuart_edma_handl
  * @brief LPUART eDMA IRQ handle function.
  *
  * This function handles the LPUART tx complete IRQ request and invoke user callback.
- * It is not set to static so that it can be used in user application.
+ * It is not set to static so that it can be used in user application (this function must
+ * be called from the IRQ handler of the LPUART peripheral if the `kLPUART_TransmissionCompleteFlag`
+ * status flag is set). This is handled by default in the weak implementation of the IRQHandler.
  *
  * @param base LPUART peripheral base address.
  * @param lpuartEdmaHandle LPUART handle pointer.


### PR DESCRIPTION
I wasted a lot of time chasing around UART issues that could have been prevented if the documentation explained that all interrupts get disabled when the user creates an EDMA handle, and that the `LPUART_TransferEdmaHandleIRQ()` function must be called on transmission complete.

Signed-off-by: Andres O. Vela <andresovela@gmail.com>

**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

A clear and concise description for the change in this Pull Request and which issue is fixed. 

Fixes # (issue)

**Type of change** (please delete options that are not relevant):

- [x] Documentation
