### PR TITLE
Patch RT1166 fsl_clock.h to fix PLL POST_DIV_SEL Constants

### DIFF
--- a/devices/MIMXRT1166/drivers/fsl_clock.h
+++ b/devices/MIMXRT1166/drivers/fsl_clock.h
@@ -1809,8 +1809,10 @@ enum _clock_pll_clk_src
  */
 typedef enum _clock_pll_post_div
 {
-    kCLOCK_PllPostDiv8 = 0U, /*!< Divide by 8. */
+    kCLOCK_PllPostDiv2 = 0U, /*!< Divide by 2. */
     kCLOCK_PllPostDiv4 = 1U, /*!< Divide by 4. */
+    kCLOCK_PllPostDiv8 = 2U, /*!< Divide by 8. */
+    kCLOCK_PllPostDiv1 = 3U, /*!< Divide by 1. */
 } clock_pll_post_div_t;
 
 /*!


### PR DESCRIPTION
**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Constants for field POST_DIV_SEL in ARM_PLL_CTRL_REGISTER were
incorrect, fix them.

**Type of change**:

- [x] Bug fix (non-breaking change which fixes an issue)

