### PR TITLE
Add missing xip cmake file for RT1160

### DIFF
--- a/boards/evkmimxrt1160/xip/driver_xip_board_evkmimxrt1160.cmake
+++ b/boards/evkmimxrt1160/xip/driver_xip_board_evkmimxrt1160.cmake
@@ -1,0 +1,14 @@
+#Description: XIP Board Driver; user_visible: True
+include_guard(GLOBAL)
+message("driver_xip_board_evkmimxrt1160 component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/evkmimxrt1160_flexspi_nor_config.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common)


### PR DESCRIPTION
Add xip file for MIMXRT1160 EVK. The driver_xip_board_<board> file is missing

**Prerequisites**
- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

A clear and concise description for the change in this Pull Request and which issue is fixed. 

Fixes # (issue)

**Type of change** (please delete options that are not relevant):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [X] Build Test
    - [ ] Run Test

