### PR TITLE
Add pmu driver cmake file

### DIFF
--- a/drivers/pmu/driver_pmu.cmake
+++ b/drivers/pmu/driver_pmu.cmake
@@ -1,0 +1,14 @@
+#Description: PMU Driver; user_visible: True
+include_guard(GLOBAL)
+message("driver_pmu component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/fsl_pmu.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common)


### PR DESCRIPTION
Adds pmu driver cmake file, in preparation for including this driver
component into Zephyr.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>

**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

The pmu driver component does not have a CMake file to allow it to be included. This PR adds a pmu driver CMake file, so this driver can be imported like other drivers are in the  Zephyr NXP hal.
