### PR TITLE
Replaced floating point comparison with integer one.

### DIFF
--- a/devices/LPC5502/drivers/fsl_clock.c
+++ b/devices/LPC5502/drivers/fsl_clock.c
@@ -1111,7 +1111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5502/system_LPC5502.c
+++ b/devices/LPC5502/system_LPC5502.c
@@ -112,7 +112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5502CPXXXX/drivers/fsl_clock.c
+++ b/devices/LPC5502CPXXXX/drivers/fsl_clock.c
@@ -1112,7 +1112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5502CPXXXX/system_LPC5502CPXXXX.c
+++ b/devices/LPC5502CPXXXX/system_LPC5502CPXXXX.c
@@ -111,7 +111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5504/drivers/fsl_clock.c
+++ b/devices/LPC5504/drivers/fsl_clock.c
@@ -1111,7 +1111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5504/system_LPC5504.c
+++ b/devices/LPC5504/system_LPC5504.c
@@ -112,7 +112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5504CPXXXX/drivers/fsl_clock.c
+++ b/devices/LPC5504CPXXXX/drivers/fsl_clock.c
@@ -1112,7 +1112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5504CPXXXX/system_LPC5504CPXXXX.c
+++ b/devices/LPC5504CPXXXX/system_LPC5504CPXXXX.c
@@ -111,7 +111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5506/drivers/fsl_clock.c
+++ b/devices/LPC5506/drivers/fsl_clock.c
@@ -1111,7 +1111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5506/system_LPC5506.c
+++ b/devices/LPC5506/system_LPC5506.c
@@ -112,7 +112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5506CPXXXX/drivers/fsl_clock.c
+++ b/devices/LPC5506CPXXXX/drivers/fsl_clock.c
@@ -1112,7 +1112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5506CPXXXX/system_LPC5506CPXXXX.c
+++ b/devices/LPC5506CPXXXX/system_LPC5506CPXXXX.c
@@ -111,7 +111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5512/drivers/fsl_clock.c
+++ b/devices/LPC5512/drivers/fsl_clock.c
@@ -1155,7 +1155,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5512/system_LPC5512.c
+++ b/devices/LPC5512/system_LPC5512.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5514/drivers/fsl_clock.c
+++ b/devices/LPC5514/drivers/fsl_clock.c
@@ -1154,7 +1154,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5514/system_LPC5514.c
+++ b/devices/LPC5514/system_LPC5514.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5516/drivers/fsl_clock.c
+++ b/devices/LPC5516/drivers/fsl_clock.c
@@ -1154,7 +1154,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5516/system_LPC5516.c
+++ b/devices/LPC5516/system_LPC5516.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5526/drivers/fsl_clock.c
+++ b/devices/LPC5526/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5526/system_LPC5526.c
+++ b/devices/LPC5526/system_LPC5526.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5528/drivers/fsl_clock.c
+++ b/devices/LPC5528/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC5528/system_LPC5528.c
+++ b/devices/LPC5528/system_LPC5528.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S04/drivers/fsl_clock.c
+++ b/devices/LPC55S04/drivers/fsl_clock.c
@@ -1111,7 +1111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S04/system_LPC55S04.c
+++ b/devices/LPC55S04/system_LPC55S04.c
@@ -112,7 +112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S06/drivers/fsl_clock.c
+++ b/devices/LPC55S06/drivers/fsl_clock.c
@@ -1111,7 +1111,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S06/system_LPC55S06.c
+++ b/devices/LPC55S06/system_LPC55S06.c
@@ -112,7 +112,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S14/drivers/fsl_clock.c
+++ b/devices/LPC55S14/drivers/fsl_clock.c
@@ -1154,7 +1154,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S14/system_LPC55S14.c
+++ b/devices/LPC55S14/system_LPC55S14.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S16/drivers/fsl_clock.c
+++ b/devices/LPC55S16/drivers/fsl_clock.c
@@ -1154,7 +1154,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S16/system_LPC55S16.c
+++ b/devices/LPC55S16/system_LPC55S16.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S26/drivers/fsl_clock.c
+++ b/devices/LPC55S26/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S26/system_LPC55S26.c
+++ b/devices/LPC55S26/system_LPC55S26.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S28/drivers/fsl_clock.c
+++ b/devices/LPC55S28/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S28/system_LPC55S28.c
+++ b/devices/LPC55S28/system_LPC55S28.c
@@ -115,7 +115,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S66/drivers/fsl_clock.c
+++ b/devices/LPC55S66/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S66/system_LPC55S66_cm33_core0.c
+++ b/devices/LPC55S66/system_LPC55S66_cm33_core0.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S66/system_LPC55S66_cm33_core1.c
+++ b/devices/LPC55S66/system_LPC55S66_cm33_core1.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S69/drivers/fsl_clock.c
+++ b/devices/LPC55S69/drivers/fsl_clock.c
@@ -1159,7 +1159,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL0_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S69/system_LPC55S69_cm33_core0.c
+++ b/devices/LPC55S69/system_LPC55S69_cm33_core0.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }

--- a/devices/LPC55S69/system_LPC55S69_cm33_core1.c
+++ b/devices/LPC55S69/system_LPC55S69_cm33_core1.c
@@ -116,7 +116,7 @@ static float findPll0MMult(void)
                        (float)(uint32_t)(1UL << PLL_SSCG_MD_INT_P));
         mMult       = (float)mMult_int + mMult_fract;
     }
-    if (mMult == 0.0F)
+    if (0ULL == ((uint64_t)mMult))
     {
         mMult = 1.0F;
     }


### PR DESCRIPTION
Signed-off-by: Alexander Goomenyuk <emerg.reanimator@gmail.com>

**Prerequisites**
- [y] I have checked latest main branch and the issue still exists.
- [y] I did not see it is stated as known-issue in release notes.
- [y] No similar GitHub issue is related to this change.
- [y] My code follows the commit guidelines of this project.
- [y] I have performed a self-review of my own code.
- [y] My changes generate no new warnings.
- [n] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Comparing a float number with == and != operators is not safe.
See https://embeddeduse.com/2019/08/26/qt-compare-two-floats/ for more details.
It is safer to cast the result to integer time to perform comparison.

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting: NXP LPC55S28-EVK
   - Toolchain: arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.2.1 20201103 (release)
   - Test Tool preparation: Use a debugger to be able to set the variable during the debugging session.
   - Any other dependencies: None
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [y] Build Test: add following compiler option: -Werror=float-equal
    - [y] Run Test: boot up the board and verify that mMult value is casted correctly while debugging.