### PR TITLE
Fix issue in FLEXCAN_EnableInterrupts and FLEXCAN_DisableInterrupts w…

### DIFF
--- a/drivers/flexcan/fsl_flexcan.h
+++ b/drivers/flexcan/fsl_flexcan.h
@@ -396,7 +396,7 @@ enum _flexcan_interrupt_enable
     kFLEXCAN_ErrorInterruptEnable     = CAN_CTRL1_ERRMSK_MASK,  /*!< CAN Error interrupt, use bit 14. */
     kFLEXCAN_TxWarningInterruptEnable = CAN_CTRL1_TWRNMSK_MASK, /*!< Tx Warning interrupt, use bit 11. */
     kFLEXCAN_RxWarningInterruptEnable = CAN_CTRL1_RWRNMSK_MASK, /*!< Rx Warning interrupt, use bit 10. */
-    kFLEXCAN_WakeUpInterruptEnable    = CAN_MCR_WAKMSK_MASK,    /*!< Self Wake Up interrupt, use bit 22. */
+    kFLEXCAN_WakeUpInterruptEnable    = CAN_MCR_WAKMSK_MASK,    /*!< Self Wake Up interrupt, use bit 26. */
 #if (defined(FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE) && FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE)
     kFLEXCAN_FDErrorInterruptEnable = CAN_CTRL2_ERRMSK_FAST_MASK, /*!< CAN FD Error interrupt, use bit 31. */
 #endif
@@ -1603,8 +1603,7 @@ static inline void FLEXCAN_EnableInterrupts(CAN_Type *base, uint32_t mask)
     /* Solve interrupt enable bits in CTRL1 register. */
     base->CTRL1 |=
         (uint32_t)(mask & ((uint32_t)kFLEXCAN_BusOffInterruptEnable | (uint32_t)kFLEXCAN_ErrorInterruptEnable |
-                           (uint32_t)kFLEXCAN_RxWarningInterruptEnable | (uint32_t)kFLEXCAN_TxWarningInterruptEnable |
-                           (uint32_t)kFLEXCAN_WakeUpInterruptEnable));
+                           (uint32_t)kFLEXCAN_RxWarningInterruptEnable | (uint32_t)kFLEXCAN_TxWarningInterruptEnable));
 }
 
 /*!
@@ -1652,8 +1651,7 @@ static inline void FLEXCAN_DisableInterrupts(CAN_Type *base, uint32_t mask)
     /* Solve interrupt enable bits in CTRL1 register. */
     base->CTRL1 &=
         ~(uint32_t)(mask & ((uint32_t)kFLEXCAN_BusOffInterruptEnable | (uint32_t)kFLEXCAN_ErrorInterruptEnable |
-                            (uint32_t)kFLEXCAN_RxWarningInterruptEnable | (uint32_t)kFLEXCAN_TxWarningInterruptEnable |
-                            (uint32_t)kFLEXCAN_WakeUpInterruptEnable));
+                            (uint32_t)kFLEXCAN_RxWarningInterruptEnable | (uint32_t)kFLEXCAN_TxWarningInterruptEnable));
 }
 
 /*!


### PR DESCRIPTION
…hich may inadvertently change PRESDIV in the CTRL1 register.

**Prerequisites**
- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Fixes an issue in fsl_flexcan.h which could inadvertently change the PRESDIV value in the CTRL1 register.

**Type of change** (please delete options that are not relevant):

- [X] Bug fix (non-breaking change which fixes an issue)

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting: 1052 EVKB dev kit
   - Toolchain: gcc arm embedded
   - Test Tool preparation: NA
   - Any other dependencies: No
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [X] Build Test
    - [X] Run Test - Tested CAN communication functioned properly on the 1052 EVKB dev board.

