### PR TITLE
mcux: Add support for mimxrt1050_evk_qspi

### DIFF
--- a/boards/evkbimxrt1050/xip/driver_xip_board_evkbimxrt1050_qspi.cmake
+++ b/boards/evkbimxrt1050/xip/driver_xip_board_evkbimxrt1050_qspi.cmake
@@ -1,0 +1,14 @@
+#Description: XIP Board Driver; user_visible: True
+include_guard(GLOBAL)
+message("driver_xip_board_evkbimxrt1050 component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/evkbimxrt1050_flexspi_nor_qspi_config.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common)

--- a/boards/evkbimxrt1050/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
+++ b/boards/evkbimxrt1050/xip/evkbimxrt1050_flexspi_nor_qspi_config.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "evkbimxrt1050_flexspi_nor_config.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.xip_board"
+#endif
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+#if defined(XIP_BOOT_HEADER_ENABLE) && (XIP_BOOT_HEADER_ENABLE == 1)
+#if defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+__attribute__((section(".boot_hdr.conf"), used))
+#elif defined(__ICCARM__)
+#pragma location = ".boot_hdr.conf"
+#endif
+
+const flexspi_nor_config_t qspiflash_config = {
+    .memConfig =
+        {
+            .tag              = FLEXSPI_CFG_BLK_TAG,
+            .version          = FLEXSPI_CFG_BLK_VERSION,
+            .readSampleClkSrc = kFlexSPIReadSampleClk_LoopbackFromDqsPad,
+            .csHoldTime       = 3u,
+            .csSetupTime      = 3u,
+            .sflashPadType    = kSerialFlash_4Pads,
+            .serialClkFreq    = kFlexSpiSerialClk_100MHz,
+            .sflashA1Size     = 8u * 1024u * 1024u,
+            .lookupTable =
+                {
+                    // Read LUTs
+                    FLEXSPI_LUT_SEQ(CMD_SDR, FLEXSPI_1PAD, 0xEB, RADDR_SDR, FLEXSPI_4PAD, 0x18),
+                    FLEXSPI_LUT_SEQ(DUMMY_SDR, FLEXSPI_4PAD, 0x06, READ_SDR, FLEXSPI_4PAD, 0x04),
+                },
+        },
+    .pageSize           = 256u,
+    .sectorSize         = 4u * 1024u,
+    .blockSize          = 64u * 1024u,
+    .isUniformBlockSize = false,
+};
+#endif /* XIP_BOOT_HEADER_ENABLE */


### PR DESCRIPTION
**Prerequisites**
- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Add support for mimxrt1050_evk_qspi. This board should support both boot-from-hyperflash and boot-from-qspi. This modification enables a modified board to boot from the on-board qspi nor chip.

Signed-off-by: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>
Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>

**Type of change** (please delete options that are not relevant):
New feature (non-breaking change which adds functionality)
