### PR TITLE
Do RTC/SRTC init/deinit calls more transparent.

### DIFF
--- a/drivers/snvs_hp/fsl_snvs_hp.c
+++ b/drivers/snvs_hp/fsl_snvs_hp.c
@@ -278,11 +278,7 @@ void SNVS_HP_RTC_Init(SNVS_Type *base, const snvs_hp_rtc_config_t *config)
 {
     assert(config != NULL);
 
-#if (!(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && \
-     defined(SNVS_HP_CLOCKS))
-    uint32_t instance = SNVS_HP_GetInstance(base);
-    CLOCK_EnableClock(s_snvsHpClock[instance]);
-#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+    SNVS_HP_Init(base);
 
     base->HPCOMR |= SNVS_HPCOMR_NPSWA_EN_MASK;
 
@@ -304,11 +300,7 @@ void SNVS_HP_RTC_Deinit(SNVS_Type *base)
 {
     base->HPCR &= ~SNVS_HPCR_RTC_EN_MASK;
 
-#if (!(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && \
-     defined(SNVS_HP_CLOCKS))
-    uint32_t instance = SNVS_HP_GetInstance(base);
-    CLOCK_DisableClock(s_snvsHpClock[instance]);
-#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+    SNVS_HP_Deinit(base);
 }
 
 /*!

--- a/drivers/snvs_lp/fsl_snvs_lp.c
+++ b/drivers/snvs_lp/fsl_snvs_lp.c
@@ -285,11 +285,7 @@ void SNVS_LP_SRTC_Init(SNVS_Type *base, const snvs_lp_srtc_config_t *config)
 {
     assert(config != NULL);
 
-#if (!(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && \
-     defined(SNVS_LP_CLOCKS))
-    uint32_t instance = SNVS_LP_GetInstance(base);
-    CLOCK_EnableClock(s_snvsLpClock[instance]);
-#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+    SNVS_LP_Init(base);
 
     int pin;
 
@@ -315,11 +311,7 @@ void SNVS_LP_SRTC_Deinit(SNVS_Type *base)
 {
     base->LPCR &= ~SNVS_LPCR_SRTC_ENV_MASK;
 
-#if (!(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && \
-     defined(SNVS_LP_CLOCKS))
-    uint32_t instance = SNVS_LP_GetInstance(base);
-    CLOCK_DisableClock(s_snvsLpClock[instance]);
-#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+    SNVS_LP_Deinit(base);
 }
 
 /*!


### PR DESCRIPTION
Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

**Prerequisites**
- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

SNVS RTC/SRTC init/deinit function are using generic code from SNVS init/deinit instead of copy/paste.

Fixes # (issue)

**Type of change** (please delete options that are not relevant):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting:
   - Toolchain:
   - Test Tool preparation:
   - Any other dependencies:
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [X] Build Test
    - [X] Run Test

