### PR TITLE
Fix the definition of ENET for i.MX RT1060 family

### DIFF
--- a/devices/MIMXRT1061/MIMXRT1061.h
+++ b/devices/MIMXRT1061/MIMXRT1061.h
@@ -20634,15 +20634,15 @@ typedef struct {
 /** Peripheral ENET2 base pointer */
 #define ENET2                                    ((ENET_Type *)ENET2_BASE)
 /** Array initializer of ENET peripheral base addresses */
-#define ENET_BASE_ADDRS                          { ENET_BASE, ENET2_BASE }
+#define ENET_BASE_ADDRS                          { ENET_BASE, 0u, ENET2_BASE }
 /** Array initializer of ENET peripheral base pointers */
-#define ENET_BASE_PTRS                           { ENET, ENET2 }
+#define ENET_BASE_PTRS                           { ENET, (ENET_Type *)0u, ENET2 }
 /** Interrupt vectors for the ENET peripheral type */
-#define ENET_Transmit_IRQS                       { ENET_IRQn, ENET2_IRQn }
-#define ENET_Receive_IRQS                        { ENET_IRQn, ENET2_IRQn }
-#define ENET_Error_IRQS                          { ENET_IRQn, ENET2_IRQn }
-#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
-#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Transmit_IRQS                       { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Receive_IRQS                        { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Error_IRQS                          { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
 /* ENET Buffer Descriptor and Buffer Address Alignment. */
 #define ENET_BUFF_ALIGNMENT                      (64U)
 

--- a/devices/MIMXRT1062/MIMXRT1062.h
+++ b/devices/MIMXRT1062/MIMXRT1062.h
@@ -21413,15 +21413,15 @@ typedef struct {
 /** Peripheral ENET2 base pointer */
 #define ENET2                                    ((ENET_Type *)ENET2_BASE)
 /** Array initializer of ENET peripheral base addresses */
-#define ENET_BASE_ADDRS                          { ENET_BASE, ENET2_BASE }
+#define ENET_BASE_ADDRS                          { ENET_BASE, 0u, ENET2_BASE }
 /** Array initializer of ENET peripheral base pointers */
-#define ENET_BASE_PTRS                           { ENET, ENET2 }
+#define ENET_BASE_PTRS                           { ENET, (ENET_Type *)0u, ENET2 }
 /** Interrupt vectors for the ENET peripheral type */
-#define ENET_Transmit_IRQS                       { ENET_IRQn, ENET2_IRQn }
-#define ENET_Receive_IRQS                        { ENET_IRQn, ENET2_IRQn }
-#define ENET_Error_IRQS                          { ENET_IRQn, ENET2_IRQn }
-#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
-#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Transmit_IRQS                       { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Receive_IRQS                        { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Error_IRQS                          { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
 /* ENET Buffer Descriptor and Buffer Address Alignment. */
 #define ENET_BUFF_ALIGNMENT                      (64U)
 

--- a/devices/MIMXRT1064/MIMXRT1064.h
+++ b/devices/MIMXRT1064/MIMXRT1064.h
@@ -21484,15 +21484,15 @@ typedef struct {
 /** Peripheral ENET2 base pointer */
 #define ENET2                                    ((ENET_Type *)ENET2_BASE)
 /** Array initializer of ENET peripheral base addresses */
-#define ENET_BASE_ADDRS                          { ENET_BASE, ENET2_BASE }
+#define ENET_BASE_ADDRS                          { ENET_BASE, 0u, ENET2_BASE }
 /** Array initializer of ENET peripheral base pointers */
-#define ENET_BASE_PTRS                           { ENET, ENET2 }
+#define ENET_BASE_PTRS                           { ENET, (ENET_Type *)0u, ENET2 }
 /** Interrupt vectors for the ENET peripheral type */
-#define ENET_Transmit_IRQS                       { ENET_IRQn, ENET2_IRQn }
-#define ENET_Receive_IRQS                        { ENET_IRQn, ENET2_IRQn }
-#define ENET_Error_IRQS                          { ENET_IRQn, ENET2_IRQn }
-#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
-#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Transmit_IRQS                       { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Receive_IRQS                        { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_Error_IRQS                          { ENET_IRQn, NotAvail_IRQn, ENET2_IRQn }
+#define ENET_1588_Timer_IRQS                     { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
+#define ENET_Ts_IRQS                             { ENET_1588_Timer_IRQn, NotAvail_IRQn, ENET2_1588_Timer_IRQn }
 /* ENET Buffer Descriptor and Buffer Address Alignment. */
 #define ENET_BUFF_ALIGNMENT                      (64U)
 


### PR DESCRIPTION
Signed-off-by: Yaoxing Shan <shanyaoxing12@outlook.com>

ENET2 does not work with the original definition because it conflicts with some other driver definitions, such as `fsl_clock.h`:

````c
/*! @brief Clock ip name array for ENET. */
#define ENET_CLOCKS \
     { \
         kCLOCK_Enet, kCLOCK_IpInvalid, kCLOCK_Enet2 \
     }
````

The driver cannot find the correct clock ip based on the index of the array.

I refer to the definition of FLEXSPI and make reasonable modifications to the definition of ENET. After the modification, ENET2 can work normally.

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: MIMXRT1061CVL5A
  - Toolchain: GNU Arm Embedded Toolchain 10.3-2021.10
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test
