### PR TITLE
Removed redefinition of `MAKE_VERSION` macro

### DIFF
--- a/middleware/usb/include/usb.h
+++ b/middleware/usb/include/usb.h
@@ -34,8 +34,6 @@
 /*! @brief USB stack version definition */
 #define USB_MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 
-#define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
-
 /*! @brief USB stack component version definition, changed with component in yaml together */
 #define USB_STACK_COMPONENT_VERSION \
     MAKE_VERSION(USB_STACK_VERSION_MAJOR, USB_STACK_VERSION_MINOR, USB_STACK_VERSION_BUGFIX)


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Any inclusion of `usb.h` gives redefinition warnings at compile time.

The `MAKE_VERSION` macro is defined in `fsl_common.h` [here](https://github.com/NXPmicro/mcux-sdk/blob/main/drivers/common/fsl_common.h#L57).

`usb.h` already includes `fsl_common.h` [here](https://github.com/NXPmicro/mcux-sdk/blob/main/middleware/usb/include/usb.h#L14), therefore the redefinition is not necessary.

**Type of change**
Bug fix (non-breaking change which fixes an issue)
