### PR TITLE
mcux-sdk: enet: fsl_enet: avoid possible race condition on timestamp

### DIFF
--- a/drivers/enet/fsl_enet.c
+++ b/drivers/enet/fsl_enet.c
@@ -2975,7 +2975,7 @@ void ENET_Ptp1588GetTimer(ENET_Type *base, enet_handle_t *handle, enet_ptp_time_
     ENET_Ptp1588GetTimerNoIrqDisable(base, handle, ptpTime);
 
     /* Get PTP timer wrap event. */
-    if (0U != (base->EIR & (uint32_t)kENET_TsTimerInterrupt))
+    if (0U != (base->EIR & (uint32_t)kENET_TsTimerInterrupt) && ptpTime->nanosecond < (ENET_NANOSECOND_ONE_SECOND / 2))
     {
         ptpTime->second++;
     }


### PR DESCRIPTION
Only correct second value if the nanosecond has reasonably value.

**Prerequisites**

- [X ] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
The K64 has only nanoseconds part of the second timer.
Second and nanosecond can not be captured at the same time.

If the nanoseconds are close to the overflow care should be taken.

The second correction should be applied if 
- after the copy of the second value and
- before the capture of the nanoseconds part
an overflow of the nanoseconds happened.
The nanosecond value is small and the second value must be incremented.

if the overflow happend 
- after the capture of the nanoseconds
- but early enough that the ISR is asserted when checking
- no second increment should be performed.
The nanosecond value is high and the second value must NOT be touched.

<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: FRDM_K64F
  - Toolchain: GCC 12.2, zephyr SDK 17.0
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [ ] Build Test
  - [ ] Run Test
